### PR TITLE
feat(chart-updater): continuous deployment of OCI Helm chart type application

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -8,6 +8,8 @@ const ImageUpdaterAnnotationPrefix = "argocd-image-updater.argoproj.io"
 // allowed for updates.
 const ImageUpdaterAnnotation = ImageUpdaterAnnotationPrefix + "/image-list"
 
+const ChartVersionAnnotation = ImageUpdaterAnnotationPrefix + "/chart-version"
+
 // Defaults for Helm parameter names
 const (
 	DefaultHelmImageName = "image.name"


### PR DESCRIPTION
Update application targetRevision for an OCI helm chart when new chart version arrives into the container registry based on semver constraints.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>